### PR TITLE
Adding Redis 4 parameters

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -172,6 +172,11 @@ define redis::server (
   $protected_mode                = undef,
   $include                       = [],
   $systemd_limitnofiles          = undef,
+  $lazyfree_lazy_eviction        = undef,
+  $lazyfree_lazy_expire          = undef,
+  $lazyfree_lazy_server_del      = undef,
+  $slave_lazy_flush              = undef,
+  $always_show_logo              = undef,
 ) {
   include redis::install
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,7 +19,7 @@
 # [*redis_socketperm*]
 #   Permission of socket file. Default: 755
 # [*redis_mempolicy*]
-#   Algorithm used to manage keys. See Redis docs for possible values. Default: noeviction
+#   Algorithm used to manage keys. See Redis docs for possible values. Default: allkeys-lru
 # [*redis_memsamples*]
 #   Number of samples to use for LRU policies. Default: 3
 # [*redis_timeout*]
@@ -129,7 +129,7 @@ define redis::server (
   $redis_usesocket               = false,
   $redis_socket                  = '/tmp/redis.sock',
   $redis_socketperm              = 755,
-  $redis_mempolicy               = 'noeviction',
+  $redis_mempolicy               = 'allkeys-lru',
   $redis_memsamples              = 3,
   $redis_timeout                 = 0,
   $redis_nr_dbs                  = 1,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,7 +19,7 @@
 # [*redis_socketperm*]
 #   Permission of socket file. Default: 755
 # [*redis_mempolicy*]
-#   Algorithm used to manage keys. See Redis docs for possible values. Default: allkeys-lru
+#   Algorithm used to manage keys. See Redis docs for possible values. Default: noeviction
 # [*redis_memsamples*]
 #   Number of samples to use for LRU policies. Default: 3
 # [*redis_timeout*]
@@ -123,13 +123,13 @@
 
 define redis::server (
   $redis_name                    = $name,
-  $redis_memory                  = '100mb',
+  $redis_memory                  = undef,
   $redis_ip                      = '127.0.0.1',
   $redis_port                    = 6379,
   $redis_usesocket               = false,
   $redis_socket                  = '/tmp/redis.sock',
   $redis_socketperm              = 755,
-  $redis_mempolicy               = 'allkeys-lru',
+  $redis_mempolicy               = 'noeviction',
   $redis_memsamples              = 3,
   $redis_timeout                 = 0,
   $redis_nr_dbs                  = 1,
@@ -171,6 +171,7 @@ define redis::server (
   $cluster_require_full_coverage = true,
   $protected_mode                = undef,
   $include                       = [],
+  $systemd_limitnofiles          = undef,
 ) {
   include redis::install
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -51,6 +51,12 @@
 # [*aof_rewrite_minsize*]
 #   Configure the minimum size in mb of the aof file to trigger size comparisons for rewriting.
 #   Default: 64 (integer)
+# [*aof_load_truncated*]
+#   Allow Redis to start even if it loaded a truncated AOF (eg. after a crash).
+#   Default: undef
+# [*aof_use_rdb_preamble*]
+#   Write an RDB preamble in the AOF file for faster rewrites and recoveries.
+#   Default: undef
 # [*redis_enabled_append_file*]
 #   Enable custom append file. Default: false
 # [*redis_append_file*]
@@ -147,6 +153,8 @@ define redis::server (
   $appendfsync_on_rewrite        = false,
   $aof_rewrite_percentage        = 100,
   $aof_rewrite_minsize           = 64,
+  $aof_load_truncated            = undef,
+  $aof_use_rdb_preamble          = undef,
   $redis_appendfsync             = 'everysec',
   $redis_enabled_append_file     = false,
   $redis_append_file             = undef,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -79,6 +79,10 @@
 #   Configure Redis replication ping slave period
 # [*repl_backlog_size*]
 #   Replication backlog size (in bytes or multiples). Default: undef
+# [*repl_diskless_sync*]
+#   Experimental. Avoid saving a RDB file on disk on the master for full sync operation when a slave connects. Instead the RDB dump is sent immediately over the network to the slave. (yes or no). Default: undef
+# [*repl_diskless_sync_delay*]
+#   Experimental. Time to delay the diskless replication operation to allow more slaves to connect and get it in parallel (in seconds). Default: undef
 # [*save*]
 #   Configure Redis save snapshotting. Example: [[900, 1], [300, 10]]. Default: []
 # [*hash_max_ziplist_entries*]
@@ -193,6 +197,8 @@ define redis::server (
   $repl_timeout                  = 60,
   $repl_ping_slave_period        = 10,
   $repl_backlog_size             = undef,
+  $repl_diskless_sync            = undef,
+  $repl_diskless_sync_delay      = undef,
   $save                          = [],
   $hash_max_ziplist_entries      = 512,
   $hash_max_ziplist_value        = 64,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -124,6 +124,32 @@
 #   By default Redis Cluster nodes stop accepting queries if they detect there
 #   is at least an hash slot uncovered.
 #
+# [*systemd_limitnofiles*]
+#   Sets LimitNOFILES in the Redis SystemD unit file. Default: undef
+#
+# [*lazyfree_lazy_eviction*]
+#   New in Redis 4. Asynchronously evicts keys. Default: undef (yes/no)
+#   DO NOT SET FOR REDIS verion 3.x or older
+#   
+# [*lazyfree_lazy_expire*]
+#   New in Redis 4. Asynchronously deletes expired keys. Default: undef (yes/no)
+#   DO NOT SET FOR REDIS verion 3.x or older
+#
+# [*lazyfree_lazy_server_del*]
+#   New in Redis 4. Uses the asynchronous deletion function in the case of implicit
+#   deletion. Default: undef (yes/no)
+#   DO NOT SET FOR REDIS verion 3.x or older
+#
+# [*slave_lazy_flush*]
+#   New in Redis 4. In the case of full data synchronization, the slave
+#   asynchronously clears all DBs. Default: undef (yes/no)
+#   DO NOT SET FOR REDIS verion 3.x or older
+#
+# [*always_show_logo*]
+#   New in Redis 4. A way to restore Redis 3 feature to always print logo in logs
+#   on service start/restart. Default: undef (yes/no)
+#   DO NOT SET FOR REDIS verion 3.x or older
+#
 # [*include*]
 #   Array of extra configs to include Example: [ '/etc/redis/local.conf' ]
 

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -280,7 +280,8 @@ rename-command <%= command %> ""
 # errors for write operations, and this may even lead to DB inconsistency.
 #
 # maxmemory <bytes>
-<% if @redis_memory != nil -%>maxmemory <%= @redis_memory %><% end -%>
+#<% if @redis_memory != nil -%>maxmemory <%= @redis_memory %><% end -%>
+<% unless @redis_memory.nil? -%>maxmemory <%= @redis_memory %><% end -%>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -280,7 +280,7 @@ rename-command <%= command %> ""
 # errors for write operations, and this may even lead to DB inconsistency.
 #
 # maxmemory <bytes>
-maxmemory <%= @redis_memory %>
+<% if @redis_memory -%>maxmemory <%= @redis_memory %><% end -%>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -280,10 +280,7 @@ rename-command <%= command %> ""
 # errors for write operations, and this may even lead to DB inconsistency.
 #
 # maxmemory <bytes>
-#<% if @redis_memory != nil -%>maxmemory <%= @redis_memory %><% end -%>
-#<% unless @redis_memory.nil? -%>maxmemory <%= @redis_memory %><% end -%>
-
-maxmemory <%= @redis_memory %>
+<% if @redis_memory -%>maxmemory <%= @redis_memory %><% end -%>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -284,7 +284,6 @@ rename-command <%= command %> ""
 #<% unless @redis_memory.nil? -%>maxmemory <%= @redis_memory %><% end -%>
 
 maxmemory <%= @redis_memory %>
-maxmemory.type <%= @redis_memory.type %>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -374,10 +374,10 @@ maxmemory-samples <%= @redis_memsamples %>
 # in order to instead release memory in a non-blocking way like if UNLINK
 # was called, using the following configuration directives:
 
-<% if @lazyfree_lazy_eviction -%>lazyfree-lazy-eviction <%= @lazyfree_lazy_eviction %><% end %>
-<% if @lazyfree_lazy_expire -%>lazyfree-lazy-expire <%= @lazyfree_lazy_expire %><% end %>
-<% if @lazyfree_lazy_server_del -%>lazyfree-lazy-server-del <%= @lazyfree_lazy_server_del %><% end %>
-<% if @slave_lazy_flush -%>slave-lazy-flush <%= @slave_lazy_flush %><% end %>
+<% if @lazyfree_lazy_eviction -%>lazyfree-lazy-eviction <%= @lazyfree_lazy_eviction %><% end -%>
+<% if @lazyfree_lazy_expire -%>lazyfree-lazy-expire <%= @lazyfree_lazy_expire %><% end -%>
+<% if @lazyfree_lazy_server_del -%>lazyfree-lazy-server-del <%= @lazyfree_lazy_server_del %><% end -%>
+<% if @slave_lazy_flush -%>slave-lazy-flush <%= @slave_lazy_flush %><% end -%>
 
 #### END
 

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -374,10 +374,10 @@ maxmemory-samples <%= @redis_memsamples %>
 # in order to instead release memory in a non-blocking way like if UNLINK
 # was called, using the following configuration directives:
 
-<% if @lazyfree_lazy_eviction -%>lazyfree-lazy-eviction <%= @lazyfree_lazy_eviction %><% end -%>
-<% if @lazyfree_lazy_expire -%>lazyfree-lazy-expire <%= @lazyfree_lazy_expire %><% end -%>
-<% if @lazyfree_lazy_server_del -%>lazyfree-lazy-server-del <%= @lazyfree_lazy_server_del %><% end -%>
-<% if @slave_lazy_flush -%>slave-lazy-flush <%= @slave_lazy_flush %><% end -%>
+<% if @lazyfree_lazy_eviction -%>lazyfree-lazy-eviction <%= @lazyfree_lazy_eviction %><% end %>
+<% if @lazyfree_lazy_expire -%>lazyfree-lazy-expire <%= @lazyfree_lazy_expire %><% end %>
+<% if @lazyfree_lazy_server_del -%>lazyfree-lazy-server-del <%= @lazyfree_lazy_server_del %><% end %>
+<% if @slave_lazy_flush -%>slave-lazy-flush <%= @slave_lazy_flush %><% end %>
 
 #### END
 

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -281,7 +281,10 @@ rename-command <%= command %> ""
 #
 # maxmemory <bytes>
 #<% if @redis_memory != nil -%>maxmemory <%= @redis_memory %><% end -%>
-<% unless @redis_memory.nil? -%>maxmemory <%= @redis_memory %><% end -%>
+#<% unless @redis_memory.nil? -%>maxmemory <%= @redis_memory %><% end -%>
+
+maxmemory <%= @redis_memory %>
+maxmemory.type <%= @redis_memory.type %>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -80,6 +80,18 @@ logfile <%= @redis_log_dir %>/redis_<%= @redis_name %>.log
 # dbid is a number between 0 and 'databases'-1
 databases <%= @redis_nr_dbs %>
 
+#### START
+# Added in Redis 4
+# By default Redis shows an ASCII art logo only when started to log to the
+# standard output and if the standard output is a TTY. Basically this means
+# that normally a logo is displayed only in interactive sessions.
+#
+# However it is possible to force the pre-4.0 behavior and always show a
+# ASCII art logo in startup logs by setting the following option to yes.
+<% if @always_show_logo -%>always-show-logo <%= @always_show_logo %><% end -%>
+
+#### END
+
 ################################ SNAPSHOTTING  #################################
 #
 # Save the DB on disk:
@@ -314,6 +326,60 @@ maxmemory-policy <%= @redis_mempolicy %>
 #
 # maxmemory-samples 3
 maxmemory-samples <%= @redis_memsamples %>
+
+
+#### START
+# Added in Redis 4
+############################# LAZY FREEING ####################################
+
+# Redis has two primitives to delete keys. One is called DEL and is a blocking
+# deletion of the object. It means that the server stops processing new commands
+# in order to reclaim all the memory associated with an object in a synchronous
+# way. If the key deleted is associated with a small object, the time needed
+# in order to execute the DEL command is very small and comparable to most other
+# O(1) or O(log_N) commands in Redis. However if the key is associated with an
+# aggregated value containing millions of elements, the server can block for
+# a long time (even seconds) in order to complete the operation.
+#
+# For the above reasons Redis also offers non blocking deletion primitives
+# such as UNLINK (non blocking DEL) and the ASYNC option of FLUSHALL and
+# FLUSHDB commands, in order to reclaim memory in background. Those commands
+# are executed in constant time. Another thread will incrementally free the
+# object in the background as fast as possible.
+#
+# DEL, UNLINK and ASYNC option of FLUSHALL and FLUSHDB are user-controlled.
+# It's up to the design of the application to understand when it is a good
+# idea to use one or the other. However the Redis server sometimes has to
+# delete keys or flush the whole database as a side effect of other operations.
+# Specifically Redis deletes objects independently of a user call in the
+# following scenarios:
+#
+# 1) On eviction, because of the maxmemory and maxmemory policy configurations,
+#    in order to make room for new data, without going over the specified
+#    memory limit.
+# 2) Because of expire: when a key with an associated time to live (see the
+#    EXPIRE command) must be deleted from memory.
+# 3) Because of a side effect of a command that stores data on a key that may
+#    already exist. For example the RENAME command may delete the old key
+#    content when it is replaced with another one. Similarly SUNIONSTORE
+#    or SORT with STORE option may delete existing keys. The SET command
+#    itself removes any old content of the specified key in order to replace
+#    it with the specified string.
+# 4) During replication, when a slave performs a full resynchronization with
+#    its master, the content of the whole database is removed in order to
+#    load the RDB file just transfered.
+#
+# In all the above cases the default is to delete objects in a blocking way,
+# like if DEL was called. However you can configure each case specifically
+# in order to instead release memory in a non-blocking way like if UNLINK
+# was called, using the following configuration directives:
+
+<% if @lazyfree_lazy_eviction -%>lazyfree-lazy-eviction <%= @lazyfree_lazy_eviction %><% end -%>
+<% if @lazyfree_lazy_expire -%>lazyfree-lazy-expire <%= @lazyfree_lazy_expire %><% end -%>
+<% if @lazyfree_lazy_server_del -%>lazyfree-lazy-server-del <%= @lazyfree_lazy_server_del %><% end -%>
+<% if @slave_lazy_flush -%>slave-lazy-flush <%= @slave_lazy_flush %><% end -%>
+
+#### END
 
 ############################## APPEND ONLY MODE ###############################
 

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -280,7 +280,7 @@ rename-command <%= command %> ""
 # errors for write operations, and this may even lead to DB inconsistency.
 #
 # maxmemory <bytes>
-<% if @redis_memory -%>maxmemory <%= @redis_memory %><% end -%>
+<% if @redis_memory != nil -%>maxmemory <%= @redis_memory %><% end -%>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -467,10 +467,53 @@ no-appendfsync-on-rewrite <% if @appendfsync_on_rewrite -%> yes <% else -%>no<% 
 # Specify a precentage of zero in order to disable the automatic AOF
 # rewrite feature.
 
-
-
 auto-aof-rewrite-percentage <%= @aof_rewrite_percentage %>
 auto-aof-rewrite-min-size <%= @aof_rewrite_minsize %>
+
+#### START
+# Added in Redis 4
+
+# An AOF file may be found to be truncated at the end during the Redis
+# startup process, when the AOF data gets loaded back into memory.
+# This may happen when the system where Redis is running
+# crashes, especially when an ext4 filesystem is mounted without the
+# data=ordered option (however this can't happen when Redis itself
+# crashes or aborts but the operating system still works correctly).
+#
+# Redis can either exit with an error when this happens, or load as much
+# data as possible (the default now) and start if the AOF file is found
+# to be truncated at the end. The following option controls this behavior.
+#
+# If aof-load-truncated is set to yes, a truncated AOF file is loaded and
+# the Redis server starts emitting a log to inform the user of the event.
+# Otherwise if the option is set to no, the server aborts with an error
+# and refuses to start. When the option is set to no, the user requires
+# to fix the AOF file using the "redis-check-aof" utility before to restart
+# the server.
+#
+# Note that if the AOF file will be found to be corrupted in the middle
+# the server will still exit with an error. This option only applies when
+# Redis will try to read more data from the AOF file but not enough bytes
+# will be found.
+#aof-load-truncated yes
+<% if @aof_load_truncated -%>aof-load-truncated <%= @aof_load_truncated %><% end -%>
+
+# When rewriting the AOF file, Redis is able to use an RDB preamble in the
+# AOF file for faster rewrites and recoveries. When this option is turned
+# on the rewritten AOF file is composed of two different stanzas:
+#
+#   [RDB file][AOF tail]
+#
+# When loading Redis recognizes that the AOF file starts with the "REDIS"
+# string and loads the prefixed RDB file, and continues loading the AOF
+# tail.
+#
+# This is currently turned off by default in order to avoid the surprise
+# of a format change, but will at some point be used as the default.
+#aof-use-rdb-preamble no
+<% if @aof_use_rdb_preamble -%>aof-use-rdb-preamble <%= @aof_use_rdb_preamble %><% end -%>
+
+#### END
 
 ################################ LUA SCRIPTING  ###############################
 

--- a/templates/etc/redis.conf.erb
+++ b/templates/etc/redis.conf.erb
@@ -182,6 +182,56 @@ slave-serve-stale-data <% if @slave_serve_stale_data -%>yes<% else -%>no<% end -
 slave-read-only <% if @slave_read_only -%>yes<% else -%>no<% end -%>
 <% end -%>
 
+#### START
+# Added in Redis 4
+
+# Replication SYNC strategy: disk or socket.
+#
+# -------------------------------------------------------
+# WARNING: DISKLESS REPLICATION IS EXPERIMENTAL CURRENTLY
+# -------------------------------------------------------
+#
+# New slaves and reconnecting slaves that are not able to continue the replication
+# process just receiving differences, need to do what is called a "full
+# synchronization". An RDB file is transmitted from the master to the slaves.
+# The transmission can happen in two different ways:
+#
+# 1) Disk-backed: The Redis master creates a new process that writes the RDB
+#                 file on disk. Later the file is transferred by the parent
+#                 process to the slaves incrementally.
+# 2) Diskless: The Redis master creates a new process that directly writes the
+#              RDB file to slave sockets, without touching the disk at all.
+#
+# With disk-backed replication, while the RDB file is generated, more slaves
+# can be queued and served with the RDB file as soon as the current child producing
+# the RDB file finishes its work. With diskless replication instead once
+# the transfer starts, new slaves arriving will be queued and a new transfer
+# will start when the current one terminates.
+#
+# When diskless replication is used, the master waits a configurable amount of
+# time (in seconds) before starting the transfer in the hope that multiple slaves
+# will arrive and the transfer can be parallelized.
+#
+# With slow disks and fast (large bandwidth) networks, diskless replication
+# works better.
+#repl-diskless-sync no
+<% if @repl_diskless_sync -%>repl-diskless-sync <%= @repl_diskless_sync %><% end -%>
+
+# When diskless replication is enabled, it is possible to configure the delay
+# the server waits in order to spawn the child that transfers the RDB via socket
+# to the slaves.
+#
+# This is important since once the transfer starts, it is not possible to serve
+# new slaves arriving, that will be queued for the next RDB transfer, so the server
+# waits a delay in order to let more slaves arrive.
+#
+# The delay is specified in seconds, and by default is 5 seconds. To disable
+# it entirely just set it to 0 seconds and the transfer will start ASAP.
+#repl-diskless-sync-delay 5
+<% if @repl_diskless_sync_delay -%>repl-diskless-sync-delay <%= @repl_diskless_sync_delay %><% end -%>
+
+#### END
+
 # Slaves send PINGs to server in a predefined interval. It's possible to change
 # this interval with the repl_ping_slave_period option. The default value is 10
 # seconds.

--- a/templates/systemd/redis.service.erb
+++ b/templates/systemd/redis.service.erb
@@ -16,7 +16,9 @@ ExecStart=/usr/bin/redis-server <%= @redis_run_dir %>/<%= @conf_file_name %> --d
 ExecStop=/usr/bin/redis-cli -p <%= @redis_port %> shutdown
 User=<%= @redis_user or 'root' %>
 Group=<%= @redis_group or 'root' %>
-<% if @systemd_limitnofiles -%>LimitNOFILE=<%= @systemd_limitnofiles %><% end %>
+<% if @systemd_limitnofiles -%>
+LimitNOFILE=<%= @systemd_limitnofiles %>
+<% end -%>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/systemd/redis.service.erb
+++ b/templates/systemd/redis.service.erb
@@ -16,7 +16,7 @@ ExecStart=/usr/bin/redis-server <%= @redis_run_dir %>/<%= @conf_file_name %> --d
 ExecStop=/usr/bin/redis-cli -p <%= @redis_port %> shutdown
 User=<%= @redis_user or 'root' %>
 Group=<%= @redis_group or 'root' %>
-<% if @systemd_limitnofiles -%>LimitNOFILE=<%= @systemd_limitnofiles %><% end -%>
+<% if @systemd_limitnofiles -%>LimitNOFILE=<%= @systemd_limitnofiles %><% end %>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/systemd/redis.service.erb
+++ b/templates/systemd/redis.service.erb
@@ -16,6 +16,7 @@ ExecStart=/usr/bin/redis-server <%= @redis_run_dir %>/<%= @conf_file_name %> --d
 ExecStop=/usr/bin/redis-cli -p <%= @redis_port %> shutdown
 User=<%= @redis_user or 'root' %>
 Group=<%= @redis_group or 'root' %>
+<% if @systemd_limitnofiles -%>LimitNOFILE=<%= @systemd_limitnofiles %><% end -%>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Started as just adding a way to set LimitNOFILES and ended up adding some optional Redis 4 parameters.

Should work with Redis 2.4+

New Redis 4 parameters should only be set for Redis 4. Older versions of Redis will fail on start up if any of those parameters are set.

This PR is a requirement for https://github.com/BrandwatchLtd/puppetserver-environments/pull/3126