### PR TITLE
Add flag to force the execution of Redis AOF repair before service start

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -156,6 +156,11 @@
 #
 # [*include*]
 #   Array of extra configs to include Example: [ '/etc/redis/local.conf' ]
+#
+# [*redis_check_aof_fix*]
+#   Boolean flag to force the execution of command "redis-check-aof --fix /path/to/appendonly.aof".
+#   Default: false
+#
 
 define redis::server (
   $redis_name                    = $name,
@@ -217,6 +222,7 @@ define redis::server (
   $lazyfree_lazy_server_del      = undef,
   $slave_lazy_flush              = undef,
   $always_show_logo              = undef,
+  $redis_check_aof_fix           = false,
 ) {
   include redis::install
 

--- a/templates/systemd/redis.service.erb
+++ b/templates/systemd/redis.service.erb
@@ -12,6 +12,9 @@ ExecStartPre=/bin/mkdir -p <%= @redis_run_dir %>
 <% end -%>
 ExecStartPre=/bin/cp -u <%= @conf_file %> <%= @redis_run_dir %>/<%= @conf_file_name %>
 ExecStartPre=/bin/chown <%= @redis_user or 'root' %>:<%= @redis_group or 'root' %> <%= @redis_run_dir %>/<%= @conf_file_name %>
+<% if @redis_check_aof_fix -%>
+ExecStartPre=/bin/bash -c "echo y | /usr/bin/redis-check-aof --fix <%= @redis_dir %>/redis_<%= @redis_name %>/appendonly.aof"
+<% end -%>
 ExecStart=/usr/bin/redis-server <%= @redis_run_dir %>/<%= @conf_file_name %> --daemonize no
 ExecStop=/usr/bin/redis-cli -p <%= @redis_port %> shutdown
 User=<%= @redis_user or 'root' %>


### PR DESCRIPTION
When testing the failover procedure if was found that a hard VM crash
would frequently lead to AOF file corruption which prevented many
Signals Redis instances from starting on a given VM (after the crash).

The only automated recovery tool for the AOF is `redis-check-aof`
command line tool and that was used to always check/fix the AOF before
starting the Redis processes.

The new flag is off by default to preserve old behaviour.

See: https://office.brandwatch.com/jira/browse/MIT-1473